### PR TITLE
Add totalContrastiveVI code

### DIFF
--- a/contrastive_vi/model/__init__.py
+++ b/contrastive_vi/model/__init__.py
@@ -1,4 +1,5 @@
 """scvi-tools Model classes for contrastive-VI."""
 from .contrastive_vi import ContrastiveVIModel as ContrastiveVI
+from .total_contrastive_vi import TotalContrastiveVIModel as TotalContrastiveVI
 
-__all__ = ["ContrastiveVI"]
+__all__ = ["ContrastiveVI", "TotalContrastiveVI"]

--- a/contrastive_vi/model/total_contrastive_vi.py
+++ b/contrastive_vi/model/total_contrastive_vi.py
@@ -1,0 +1,748 @@
+"""Model class for contrastive-VI for single cell expression data."""
+
+import logging
+import warnings
+from collections.abc import Iterable as IterableClass
+from functools import partial
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+import torch
+from anndata import AnnData
+
+from scvi import REGISTRY_KEYS
+from scvi.dataloaders import AnnDataLoader
+from scvi._compat import Literal
+from scvi._types import Number
+from scvi._utils import _doc_params
+from scvi.data import AnnDataManager
+from scvi.data._utils import _check_nonnegative_integers
+from scvi.data.fields import (
+    CategoricalJointObsField,
+    CategoricalObsField,
+    LayerField,
+    NumericalJointObsField,
+    NumericalObsField,
+    ProteinObsmField,
+)
+from scvi.dataloaders import DataSplitter
+from scvi.model._utils import (
+    _get_batch_code_from_category,
+    _init_library_size,
+    cite_seq_raw_counts_properties,
+)
+from scvi.model.base._utils import _de_core
+from scvi.utils._docstrings import setup_anndata_dsp
+
+from contrastive_vi.model.base.training_mixin import ContrastiveTrainingMixin
+from contrastive_vi.module.total_contrastive_vi import TotalContrastiveVIModule
+
+from scvi.model.base import BaseModelClass
+
+logger = logging.getLogger(__name__)
+Number = Union[int, float]
+
+
+class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
+    """
+    Model class for total-contrastiveVI.
+    Args:
+    ----
+        adata: AnnData object that has been registered via
+            `TotalContrastiveVIModel.setup_anndata`.
+        n_batch: Number of batches. If 0, no batch effect correction is performed.
+        n_hidden: Number of nodes per hidden layer.
+        n_background_latent: Dimensionality of the background latent space.
+        n_salient_latent: Dimensionality of the salient latent space.
+        n_layers: Number of hidden layers used for encoder and decoder NNs.
+        dropout_rate: Dropout rate for neural networks.
+        protein_batch_mask: Dictionary where each key is a batch code, and value is for
+            each protein, whether it was observed or not.
+        use_observed_lib_size: Use observed library size for RNA as scaling factor in
+            mean of conditional distribution.
+        empirical_protein_background_prior: Set the initialization of protein
+            background prior empirically. This option fits a GMM for each of
+            100 cells per batch and averages the distributions. Note that even with
+            this option set to `True`, this only initializes a parameter that is
+            learned during inference. If `False`, randomly initializes. The default
+            (`None`), sets this to `True` if greater than 10 proteins are used.
+    """
+
+    def __init__(
+        self,
+        adata: AnnData,
+        n_hidden: int = 128,
+        n_background_latent: int = 10,
+        n_salient_latent: int = 10,
+        gene_dispersion: Literal[
+            "gene", "gene-batch", "gene-label", "gene-cell"
+        ] = "gene",
+        protein_dispersion: Literal[
+            "protein", "protein-batch", "protein-label"
+        ] = "protein",
+        gene_likelihood: Literal["zinb", "nb"] = "nb",
+        latent_distribution: Literal["normal", "ln"] = "normal",
+        empirical_protein_background_prior: Optional[bool] = None,
+        override_missing_proteins: bool = False,
+        **model_kwargs,
+    ) -> None:
+        super(TotalContrastiveVIModel, self).__init__(adata)
+
+        self.protein_state_registry = self.adata_manager.get_state_registry(
+            REGISTRY_KEYS.PROTEIN_EXP_KEY
+        )
+        if (
+            ProteinObsmField.PROTEIN_BATCH_MASK in self.protein_state_registry
+            and not override_missing_proteins
+        ):
+            batch_mask = self.protein_state_registry.protein_batch_mask
+            msg = (
+                "Some proteins have all 0 counts in some batches. "
+                + "These proteins will be treated as missing measurements; however, "
+                + "this can occur due to experimental design/biology. "
+                + "Reinitialize the model with `override_missing_proteins=True`,"
+                + "to override this behavior."
+            )
+            warnings.warn(msg, UserWarning)
+            self._use_adversarial_classifier = True
+        else:
+            batch_mask = None
+            self._use_adversarial_classifier = False
+
+        emp_prior = (
+            empirical_protein_background_prior
+            if empirical_protein_background_prior is not None
+            else (self.summary_stats.n_proteins > 10)
+        )
+        if emp_prior:
+            prior_mean, prior_scale = self._get_totalvi_protein_priors(adata)
+        else:
+            prior_mean, prior_scale = None, None
+
+        n_cats_per_cov = (
+            self.adata_manager.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY)[
+                CategoricalJointObsField.N_CATS_PER_KEY
+            ]
+            if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
+            else None
+        )
+
+        n_batch = self.summary_stats.n_batch
+        use_size_factor_key = (
+            REGISTRY_KEYS.SIZE_FACTOR_KEY in self.adata_manager.data_registry
+        )
+        library_log_means, library_log_vars = None, None
+        if not use_size_factor_key:
+            library_log_means, library_log_vars = _init_library_size(
+                self.adata_manager, n_batch
+            )
+
+        self.module = TotalContrastiveVIModule(
+            n_input_genes=self.summary_stats["n_vars"],
+            n_input_proteins=self.summary_stats["n_proteins"],
+            n_batch=n_batch,
+            n_background_latent=n_background_latent,
+            n_salient_latent=n_salient_latent,
+            n_continuous_cov=self.summary_stats.get("n_extra_continuous_covs", 0),
+            n_cats_per_cov=n_cats_per_cov,
+            gene_dispersion=gene_dispersion,
+            protein_dispersion=protein_dispersion,
+            gene_likelihood=gene_likelihood,
+            latent_distribution=latent_distribution,
+            protein_batch_mask=batch_mask,
+            protein_background_prior_mean=prior_mean,
+            protein_background_prior_scale=prior_scale,
+            use_size_factor_key=use_size_factor_key,
+            library_log_means=library_log_means,
+            library_log_vars=library_log_vars,
+            **model_kwargs,
+        )
+        self._model_summary_string = "totalContrastiveVI."
+        # Necessary line to get params to be used for saving and loading.
+        self.init_params_ = self._get_init_params(locals())
+        logger.info("The model has been initialized")
+
+    @classmethod
+    @setup_anndata_dsp.dedent
+    def setup_anndata(
+        cls,
+        adata: AnnData,
+        protein_expression_obsm_key: str,
+        protein_names_uns_key: Optional[str] = None,
+        batch_key: Optional[str] = None,
+        layer: Optional[str] = None,
+        size_factor_key: Optional[str] = None,
+        categorical_covariate_keys: Optional[List[str]] = None,
+        continuous_covariate_keys: Optional[List[str]] = None,
+        **kwargs,
+    ) -> Optional[AnnData]:
+        """
+        %(summary)s.
+        Parameters
+        ----------
+        %(param_adata)s
+        protein_expression_obsm_key
+            key in `adata.obsm` for protein expression data.
+        protein_names_uns_key
+            key in `adata.uns` for protein names. If None, will use the column names of `adata.obsm[protein_expression_obsm_key]`
+            if it is a DataFrame, else will assign sequential names to proteins.
+        %(param_batch_key)s
+        %(param_layer)s
+        %(param_size_factor_key)s
+        %(param_cat_cov_keys)s
+        %(param_cont_cov_keys)s
+        %(param_copy)s
+        Returns
+        -------
+        %(returns)s
+        """
+        setup_method_args = cls._get_setup_method_args(**locals())
+        batch_field = CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key)
+        anndata_fields = [
+            LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),
+            CategoricalObsField(
+                REGISTRY_KEYS.LABELS_KEY, None
+            ),  # Default labels field for compatibility with TOTALVAE
+            batch_field,
+            NumericalObsField(
+                REGISTRY_KEYS.SIZE_FACTOR_KEY, size_factor_key, required=False
+            ),
+            CategoricalJointObsField(
+                REGISTRY_KEYS.CAT_COVS_KEY, categorical_covariate_keys
+            ),
+            NumericalJointObsField(
+                REGISTRY_KEYS.CONT_COVS_KEY, continuous_covariate_keys
+            ),
+            ProteinObsmField(
+                REGISTRY_KEYS.PROTEIN_EXP_KEY,
+                protein_expression_obsm_key,
+                use_batch_mask=True,
+                batch_key=batch_field.attr_key,
+                colnames_uns_key=protein_names_uns_key,
+                is_count_data=True,
+            ),
+        ]
+        adata_manager = AnnDataManager(
+            fields=anndata_fields, setup_method_args=setup_method_args
+        )
+        adata_manager.register_fields(adata, **kwargs)
+        cls.register_manager(adata_manager)
+
+    @torch.no_grad()
+    def get_latent_representation(
+        self,
+        adata: Optional[AnnData] = None,
+        indices: Optional[Sequence[int]] = None,
+        give_mean: bool = True,
+        batch_size: Optional[int] = None,
+        representation_kind: str = "salient",
+    ) -> np.ndarray:
+        """
+        Return the background or salient latent representation for each cell.
+
+        Args:
+        ----
+        adata: AnnData object with equivalent structure to initial AnnData. If `None`,
+            defaults to the AnnData object used to initialize the model.
+        indices: Indices of cells in adata to use. If `None`, all cells are used.
+        give_mean: Give mean of distribution or sample from it.
+        batch_size: Mini-batch size for data loading into model. Defaults to
+            `scvi.settings.batch_size`.
+        representation_kind: Either "background" or "salient" for the corresponding
+            representation kind.
+
+        Returns
+        -------
+            A numpy array with shape `(n_cells, n_latent)`.
+        """
+        available_representation_kinds = ["background", "salient"]
+        assert representation_kind in available_representation_kinds, (
+            f"representation_kind = {representation_kind} is not one of"
+            f" {available_representation_kinds}"
+        )
+
+        adata = self._validate_anndata(adata)
+        data_loader = self._make_data_loader(
+            adata=adata,
+            indices=indices,
+            batch_size=batch_size,
+            shuffle=False,
+            data_loader_class=AnnDataLoader,
+        )
+        latent = []
+        for tensors in data_loader:
+            x = tensors[REGISTRY_KEYS.X_KEY]
+            y = tensors[REGISTRY_KEYS.PROTEIN_EXP_KEY]
+            batch_index = tensors[REGISTRY_KEYS.BATCH_KEY]
+            outputs = self.module._generic_inference(
+                x=x, y=y, batch_index=batch_index, n_samples=1
+            )
+
+            if representation_kind == "background":
+                latent_m = outputs["qz_m"]
+                latent_sample = outputs["z"]
+            else:
+                latent_m = outputs["qs_m"]
+                latent_sample = outputs["s"]
+
+            if give_mean:
+                latent_sample = latent_m
+
+            latent += [latent_sample.detach().cpu()]
+        return torch.cat(latent).numpy()
+
+    @torch.no_grad()
+    def get_normalized_expression(
+        self,
+        adata=None,
+        indices=None,
+        n_samples_overall: Optional[int] = None,
+        transform_batch: Optional[Sequence[Union[Number, str]]] = None,
+        gene_list: Optional[Sequence[str]] = None,
+        protein_list: Optional[Sequence[str]] = None,
+        library_size: Optional[Union[float, Literal["latent"]]] = 1,
+        n_samples: int = 1,
+        sample_protein_mixing: bool = False,
+        scale_protein: bool = False,
+        include_protein_background: bool = False,
+        batch_size: Optional[int] = None,
+        return_mean: bool = True,
+        return_numpy: Optional[bool] = None,
+    ) -> Dict[
+        str, Tuple[Union[np.ndarray, pd.DataFrame], Union[np.ndarray, pd.DataFrame]]
+    ]:
+        r"""
+        Returns the normalized gene expression and protein expression.
+        This is denoted as :math:`\rho_n` in the totalVI paper for genes, and TODO
+        for proteins, :math:`(1-\pi_{nt})\alpha_{nt}\beta_{nt}`.
+        Parameters
+        ----------
+        adata
+            AnnData object with equivalent structure to initial AnnData. If `None`,
+            defaults to the AnnData object used to initialize the model.
+        indices
+            Indices of cells in adata to use. If `None`, all cells are used.
+        n_samples_overall
+            Number of samples to use in total
+        transform_batch
+            Batch to condition on.
+            If transform_batch is:
+            - None, then real observed batch is used
+            - int, then batch transform_batch is used
+            - List[int], then average over batches in list
+        gene_list
+            Return frequencies of expression for a subset of genes.
+            This can save memory when working with large datasets and few genes are
+            of interest.
+        protein_list
+            Return protein expression for a subset of genes.
+            This can save memory when working with large datasets and few genes are
+            of interest.
+        library_size
+            Scale the expression frequencies to a common library size.
+            This allows gene expression levels to be interpreted on a common scale of
+            relevant magnitude.
+        n_samples
+            Get sample scale from multiple samples.
+        sample_protein_mixing
+            Sample mixing bernoulli, setting background to zero
+        scale_protein
+            Make protein expression sum to 1
+        include_protein_background
+            Include background component for protein expression
+        batch_size
+            Minibatch size for data loading into model. Defaults to
+            `scvi.settings.batch_size`.
+        return_mean
+            Whether to return the mean of the samples.
+        return_numpy
+            Return a `np.ndarray` instead of a `pd.DataFrame`. Includes gene
+            names as columns. If either n_samples=1 or return_mean=True, defaults to
+            False. Otherwise, it defaults to True.
+        Returns
+        -------
+        - **gene_normalized_expression** - normalized expression for RNA
+        - **protein_normalized_expression** - normalized expression for proteins
+        If ``n_samples`` > 1 and ``return_mean`` is False, then the shape is
+        ``(samples, cells, genes)``. Otherwise, shape is ``(cells, genes)``.
+        Return type is ``pd.DataFrame`` unless ``return_numpy`` is True.
+        """
+        adata = self._validate_anndata(adata)
+        if indices is None:
+            indices = np.arange(adata.n_obs)
+        if n_samples_overall is not None:
+            indices = np.random.choice(indices, n_samples_overall)
+        post = self._make_data_loader(
+            adata=adata, indices=indices, batch_size=batch_size
+        )
+
+        if gene_list is None:
+            gene_mask = slice(None)
+        else:
+            all_genes = adata.var_names
+            gene_mask = [True if gene in gene_list else False for gene in all_genes]
+        if protein_list is None:
+            protein_mask = slice(None)
+        else:
+            all_proteins = self.scvi_setup_dict_["protein_names"]
+            protein_mask = [True if p in protein_list else False for p in all_proteins]
+        if indices is None:
+            indices = np.arange(adata.n_obs)
+
+        if n_samples > 1 and return_mean is False:
+            if return_numpy is False:
+                warnings.warn(
+                    "return_numpy must be True if n_samples > 1 and return_mean is "
+                    "False, returning np.ndarray"
+                )
+            return_numpy = True
+
+        if not isinstance(transform_batch, IterableClass):
+            transform_batch = [transform_batch]
+
+        transform_batch = _get_batch_code_from_category(adata, transform_batch)
+
+        results = {}
+        for expression_type in ["salient", "background"]:
+            scale_list_gene = []
+            scale_list_pro = []
+
+            for tensors in post:
+                x = tensors[REGISTRY_KEYS.X_KEY]
+                y = tensors[REGISTRY_KEYS.PROTEIN_EXP_KEY]
+                batch_original = tensors[REGISTRY_KEYS.BATCH_KEY]
+                px_scale = torch.zeros_like(x)
+                py_scale = torch.zeros_like(y)
+                if n_samples > 1:
+                    px_scale = torch.stack(n_samples * [px_scale])
+                    py_scale = torch.stack(n_samples * [py_scale])
+                for b in transform_batch:
+                    inference_outputs = self.module._generic_inference(
+                        x=x, y=y, batch_index=batch_original, n_samples=n_samples
+                    )
+
+                    if expression_type == "salient":
+                        s = inference_outputs["s"]
+                    elif expression_type == "background":
+                        s = torch.zeros_like(inference_outputs["s"])
+                    else:
+                        raise NotImplementedError("Invalid expression type provided")
+
+                    generative_outputs = self.module._generic_generative(
+                        z=inference_outputs["z"],
+                        s=s,
+                        library_gene=inference_outputs["library_gene"],
+                        batch_index=b,
+                    )
+
+                    if library_size == "latent":
+                        px_scale += generative_outputs["px_"]["rate"].cpu()
+                    else:
+                        px_scale += generative_outputs["px_"]["scale"].cpu()
+                    px_scale = px_scale[..., gene_mask]
+
+                    py_ = generative_outputs["py_"]
+                    # probability of background
+                    protein_mixing = 1 / (1 + torch.exp(-py_["mixing"].cpu()))
+                    if sample_protein_mixing is True:
+                        protein_mixing = torch.distributions.Bernoulli(
+                            protein_mixing
+                        ).sample()
+                    protein_val = py_["rate_fore"].cpu() * (1 - protein_mixing)
+                    if include_protein_background is True:
+                        protein_val += py_["rate_back"].cpu() * protein_mixing
+
+                    if scale_protein is True:
+                        protein_val = torch.nn.functional.normalize(
+                            protein_val, p=1, dim=-1
+                        )
+                    protein_val = protein_val[..., protein_mask]
+                    py_scale += protein_val
+                px_scale /= len(transform_batch)
+                py_scale /= len(transform_batch)
+                scale_list_gene.append(px_scale)
+                scale_list_pro.append(py_scale)
+
+            if n_samples > 1:
+                # concatenate along batch dimension
+                # -> result shape = (samples, cells, features)
+                scale_list_gene = torch.cat(scale_list_gene, dim=1)
+                scale_list_pro = torch.cat(scale_list_pro, dim=1)
+                # (cells, features, samples)
+                scale_list_gene = scale_list_gene.permute(1, 2, 0)
+                scale_list_pro = scale_list_pro.permute(1, 2, 0)
+            else:
+                scale_list_gene = torch.cat(scale_list_gene, dim=0)
+                scale_list_pro = torch.cat(scale_list_pro, dim=0)
+
+            if return_mean is True and n_samples > 1:
+                scale_list_gene = torch.mean(scale_list_gene, dim=-1)
+                scale_list_pro = torch.mean(scale_list_pro, dim=-1)
+
+            scale_list_gene = scale_list_gene.cpu().numpy()
+            scale_list_pro = scale_list_pro.cpu().numpy()
+            if return_numpy is None or return_numpy is False:
+                gene_df = pd.DataFrame(
+                    scale_list_gene,
+                    columns=adata.var_names[gene_mask],
+                    index=adata.obs_names[indices],
+                )
+                pro_df = pd.DataFrame(
+                    scale_list_pro,
+                    columns=self.scvi_setup_dict_["protein_names"][protein_mask],
+                    index=adata.obs_names[indices],
+                )
+
+                results[expression_type] = (gene_df, pro_df)
+            else:
+                results[expression_type] = (scale_list_gene, scale_list_pro)
+        return results
+
+    @torch.no_grad()
+    def get_specific_normalized_expression(
+        self,
+        adata=None,
+        indices=None,
+        n_samples_overall=None,
+        transform_batch: Optional[Sequence[Union[Number, str]]] = None,
+        scale_protein=False,
+        batch_size: Optional[int] = None,
+        n_samples=1,
+        sample_protein_mixing=False,
+        include_protein_background=False,
+        return_mean=True,
+        return_numpy=True,
+        expression_type: Optional[str] = None,
+        indices_to_return_salient: Optional[Sequence[int]] = None,
+    ):
+        """
+        Return normalized (decoded) gene and protein expression.
+
+        Gene + protein expressions are decoded from either the background or salient
+        latent space. One of `expression_type` or `indices_to_return_salient` should
+        have an input argument.
+
+        Args:
+        ----
+        adata:
+            AnnData object with equivalent structure to initial AnnData. If `None`,
+            defaults to the AnnData object used to initialize the model.
+        indices: Indices of cells in adata to use. If `None`, all cells are used.
+        n_samples_overall: The number of random samples in `adata` to use.
+        transform_batch:
+            Batch to condition on.
+            If transform_batch is:
+            - None, then real observed batch is used
+            - int, then batch transform_batch is used
+            - List[int], then average over batches in list
+        scale_protein: Make protein expression sum to 1
+        batch_size:
+            Minibatch size for data loading into model. Defaults to
+            `scvi.settings.batch_size`.
+        sample_protein_mixing: Sample mixing bernoulli, setting background to zero
+        include_protein_background: Include background component for protein expression
+        return_mean: Whether to return the mean of the samples.
+        return_numpy:
+            Return a `np.ndarray` instead of a `pd.DataFrame`. Includes gene
+            names as columns. If either n_samples=1 or return_mean=True, defaults to
+            False. Otherwise, it defaults to True.
+        expression_type: One of {"salient", "background"} to specify the type of
+            normalized expression to return.
+        indices_to_return_salient: If `indices` is a subset of
+            `indices_to_return_salient`, normalized expressions derived from background
+            and salient latent embeddings are returned. If `indices` is not `None` and
+            is not a subset of `indices_to_return_salient`, normalized expressions
+            derived only from background latent embeddings are returned.
+
+        Returns
+        -------
+            If `n_samples` > 1 and `return_mean` is `False`, then the shape is
+            `((samples, cells, genes), (samples, cells, proteins))`. Otherwise, shape
+            is `((cells, genes), (cells, proteins))`. In this case, return type is
+            Tuple[`pandas.DataFrame`] unless `return_numpy` is `True`.
+        """
+        is_expression_type_none = expression_type is None
+        is_indices_to_return_salient_none = indices_to_return_salient is None
+        if is_expression_type_none and is_indices_to_return_salient_none:
+            raise ValueError(
+                "Both expression_type and indices_to_return_salient are None! "
+                "Exactly one of them needs to be supplied with an input argument."
+            )
+        elif (not is_expression_type_none) and (not is_indices_to_return_salient_none):
+            raise ValueError(
+                "Both expression_type and indices_to_return_salient have an input "
+                "argument! Exactly one of them needs to be supplied with an input "
+                "argument."
+            )
+        else:
+            exprs = self.get_normalized_expression(
+                adata=adata,
+                indices=indices,
+                n_samples_overall=n_samples_overall,
+                transform_batch=transform_batch,
+                return_numpy=return_numpy,
+                return_mean=return_mean,
+                n_samples=n_samples,
+                batch_size=batch_size,
+                scale_protein=scale_protein,
+                sample_protein_mixing=sample_protein_mixing,
+                include_protein_background=include_protein_background,
+            )
+            if not is_expression_type_none:
+                return exprs[expression_type]
+            else:
+                if indices is None:
+                    indices = np.arange(adata.n_obs)
+                if set(indices).issubset(set(indices_to_return_salient)):
+                    return exprs["salient"]
+                else:
+                    return exprs["background"]
+
+    def _expression_for_de(
+        self,
+        adata=None,
+        indices=None,
+        n_samples_overall=None,
+        transform_batch: Optional[Sequence[Union[Number, str]]] = None,
+        scale_protein=False,
+        batch_size: Optional[int] = None,
+        n_samples=1,
+        sample_protein_mixing=False,
+        include_protein_background=False,
+        protein_prior_count=0.5,
+        expression_type: Optional[str] = None,
+        indices_to_return_salient: Optional[Sequence[int]] = None,
+    ):
+        rna, protein = self.get_specific_normalized_expression(
+            adata=adata,
+            indices=indices,
+            n_samples_overall=n_samples_overall,
+            transform_batch=transform_batch,
+            return_numpy=True,
+            n_samples=n_samples,
+            batch_size=batch_size,
+            scale_protein=scale_protein,
+            sample_protein_mixing=sample_protein_mixing,
+            include_protein_background=include_protein_background,
+            expression_type=expression_type,
+            indices_to_return_salient=indices_to_return_salient,
+        )
+        protein += protein_prior_count
+
+        joint = np.concatenate([rna, protein], axis=1)
+        return joint
+
+    def differential_expression(
+        self,
+        adata: Optional[AnnData] = None,
+        groupby: Optional[str] = None,
+        group1: Optional[Iterable[str]] = None,
+        group2: Optional[str] = None,
+        idx1: Optional[Union[Sequence[int], Sequence[bool], str]] = None,
+        idx2: Optional[Union[Sequence[int], Sequence[bool], str]] = None,
+        mode: Literal["vanilla", "change"] = "change",
+        delta: float = 0.25,
+        batch_size: Optional[int] = None,
+        all_stats: bool = True,
+        batch_correction: bool = False,
+        batchid1: Optional[Iterable[str]] = None,
+        batchid2: Optional[Iterable[str]] = None,
+        fdr_target: float = 0.05,
+        silent: bool = False,
+        protein_prior_count: float = 0.1,
+        scale_protein: bool = False,
+        sample_protein_mixing: bool = False,
+        include_protein_background: bool = False,
+        target_idx: Optional[Sequence[int]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
+        r"""
+        A unified method for differential expression analysis.
+        Implements `"vanilla"` DE [Lopez18]_ and `"change"` mode DE [Boyeau19]_.
+
+        Args:
+        ----
+        protein_prior_count:
+            Prior count added to protein expression before LFC computation
+        scale_protein:
+            Force protein values to sum to one in every single cell
+            (post-hoc normalization).
+        sample_protein_mixing:
+            Sample the protein mixture component, i.e., use the parameter to sample a
+            Bernoulli that determines if expression is from foreground/background.
+        include_protein_background:
+            Include the protein background component as part of the protein expression
+        target_idx: If not `None`, a boolean or integer identifier should be used for
+            cells in the contrastive target group. Normalized expression values derived
+            from both salient and background latent embeddings are used when
+            {group1, group2} is a subset of the target group, otherwise background
+            normalized expression values are used.
+        **kwargs:
+            Keyword args for
+            :meth:`scvi.model.base.DifferentialComputation.get_bayes_factors`
+
+        Returns
+        -------
+        Differential expression DataFrame.
+        """
+        adata = self._validate_anndata(adata)
+        col_names = np.concatenate(
+            [
+                np.asarray(adata.var_names),
+                self.protein_state_registry.column_names,
+            ]
+        )
+
+        if target_idx is not None:
+            target_idx = np.array(target_idx)
+            if target_idx.dtype is np.dtype("bool"):
+                assert (
+                    len(target_idx) == adata.n_obs
+                ), "target_idx mask must be the same length as adata!"
+                target_idx = np.arange(adata.n_obs)[target_idx]
+            model_fn = partial(
+                self._expression_for_de,
+                scale_protein=scale_protein,
+                sample_protein_mixing=sample_protein_mixing,
+                include_protein_background=include_protein_background,
+                protein_prior_count=protein_prior_count,
+                batch_size=batch_size,
+                expression_type=None,
+                indices_to_return_salient=target_idx,
+                n_samples=100,
+            )
+        else:
+            model_fn = partial(
+                self._expression_for_de,
+                scale_protein=scale_protein,
+                sample_protein_mixing=sample_protein_mixing,
+                include_protein_background=include_protein_background,
+                protein_prior_count=protein_prior_count,
+                batch_size=batch_size,
+                expression_type="salient",
+                n_samples=100,
+            )
+
+        result = _de_core(
+            adata,
+            model_fn,
+            groupby,
+            group1,
+            group2,
+            idx1,
+            idx2,
+            all_stats,
+            cite_seq_raw_counts_properties,
+            col_names,
+            mode,
+            batchid1,
+            batchid2,
+            delta,
+            batch_correction,
+            fdr_target,
+            silent,
+            **kwargs,
+        )
+
+        return result

--- a/contrastive_vi/module/total_contrastive_vi.py
+++ b/contrastive_vi/module/total_contrastive_vi.py
@@ -1,0 +1,738 @@
+"""PyTorch module for Contrastive VI for single cell expression data."""
+
+from typing import Dict, Optional, Tuple, Union, Literal, Iterable
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from scvi import REGISTRY_KEYS
+from scvi.distributions import NegativeBinomial, NegativeBinomialMixture
+from scvi.module.base import BaseModuleClass, LossRecorder, auto_move_data
+from scvi.nn import DecoderTOTALVI, EncoderTOTALVI, one_hot
+from torch.distributions import Normal
+from torch.distributions import kl_divergence as kl
+
+torch.backends.cudnn.benchmark = True
+
+
+class TotalContrastiveVIModule(BaseModuleClass):
+    """
+    PyTorch module for total-contrastiveVI (contrastive analysis for CITE-seq).
+
+    Args:
+    ----
+        n_input_genes: Number of input genes.
+        n_input_proteins: Number of input proteins.
+        n_batch: Number of batches. If 0, no batch effect correction is performed.
+        n_hidden: Number of nodes per hidden layer.
+        n_background_latent: Dimensionality of the background latent space.
+        n_salient_latent: Dimensionality of the salient latent space.
+        n_layers: Number of hidden layers used for encoder and decoder NNs.
+        dropout_rate: Dropout rate for neural networks.
+        protein_batch_mask: Dictionary where each key is a batch code, and value is for
+            each protein, whether it was observed or not.
+        use_observed_lib_size: Use observed library size for RNA as scaling factor in
+            mean of conditional distribution.
+        library_log_means: 1 x n_batch array of means of the log library sizes.
+            Parameterize prior on library size if not using observed library size.
+        library_log_vars: 1 x n_batch array of variances of the log library sizes.
+            Parameterize prior on library size if not using observed library size.
+    """
+
+    def __init__(
+        self,
+        n_input_genes: int,
+        n_input_proteins: int,
+        n_batch: int = 0,
+        n_labels: int = 0,
+        n_hidden: int = 128,
+        n_background_latent: int = 10,
+        n_salient_latent: int = 10,
+        n_layers_encoder: int = 2,
+        n_layers_decoder: int = 1,
+        n_continuous_cov: int = 0,
+        n_cats_per_cov: Optional[Iterable[int]] = None,
+        dropout_rate_decoder: float = 0.2,
+        dropout_rate_encoder: float = 0.2,
+        gene_dispersion: str = "gene",
+        protein_dispersion: str = "protein",
+        log_variational: bool = True,
+        gene_likelihood: str = "nb",
+        latent_distribution: str = "normal",
+        protein_batch_mask: Dict[Union[str, int], np.ndarray] = None,
+        encode_covariates: bool = True,
+        protein_background_prior_mean: Optional[np.ndarray] = None,
+        protein_background_prior_scale: Optional[np.ndarray] = None,
+        use_size_factor_key: bool = False,
+        use_observed_lib_size: bool = True,
+        library_log_means: Optional[np.ndarray] = None,
+        library_log_vars: Optional[np.ndarray] = None,
+        use_batch_norm: Literal["encoder", "decoder", "none", "both"] = "both",
+        use_layer_norm: Literal["encoder", "decoder", "none", "both"] = "none",
+    ) -> None:
+        super().__init__()
+        self.gene_dispersion = gene_dispersion
+        self.n_background_latent = n_background_latent
+        self.n_salient_latent = n_salient_latent
+        self.log_variational = log_variational
+        self.gene_likelihood = gene_likelihood
+        self.n_batch = n_batch
+        self.n_labels = n_labels
+        self.n_input_genes = n_input_genes
+        self.n_input_proteins = n_input_proteins
+        self.protein_dispersion = protein_dispersion
+        self.latent_distribution = latent_distribution
+        self.protein_batch_mask = protein_batch_mask
+        self.encode_covariates = encode_covariates
+        self.use_size_factor_key = use_size_factor_key
+        self.use_observed_lib_size = use_size_factor_key or use_observed_lib_size
+        if not self.use_observed_lib_size:
+            if library_log_means is None or library_log_means is None:
+                raise ValueError(
+                    "If not using observed_lib_size, "
+                    "must provide library_log_means and library_log_vars."
+                )
+
+            self.register_buffer(
+                "library_log_means", torch.from_numpy(library_log_means).float()
+            )
+            self.register_buffer(
+                "library_log_vars", torch.from_numpy(library_log_vars).float()
+            )
+
+        # parameters for prior on rate_back (background protein mean)
+        if protein_background_prior_mean is None:
+            if n_batch > 0:
+                self.background_pro_alpha = torch.nn.Parameter(
+                    torch.randn(n_input_proteins, n_batch)
+                )
+                self.background_pro_log_beta = torch.nn.Parameter(
+                    torch.clamp(torch.randn(n_input_proteins, n_batch), -10, 1)
+                )
+            else:
+                self.background_pro_alpha = torch.nn.Parameter(
+                    torch.randn(n_input_proteins)
+                )
+                self.background_pro_log_beta = torch.nn.Parameter(
+                    torch.clamp(torch.randn(n_input_proteins), -10, 1)
+                )
+        else:
+            if protein_background_prior_mean.shape[1] == 1 and n_batch != 1:
+                init_mean = protein_background_prior_mean.ravel()
+                init_scale = protein_background_prior_scale.ravel()
+            else:
+                init_mean = protein_background_prior_mean
+                init_scale = protein_background_prior_scale
+            self.background_pro_alpha = torch.nn.Parameter(
+                torch.from_numpy(init_mean.astype(np.float32))
+            )
+            self.background_pro_log_beta = torch.nn.Parameter(
+                torch.log(torch.from_numpy(init_scale.astype(np.float32)))
+            )
+
+        if self.gene_dispersion == "gene":
+            self.px_r = torch.nn.Parameter(torch.randn(n_input_genes))
+        elif self.gene_dispersion == "gene-batch":
+            self.px_r = torch.nn.Parameter(torch.randn(n_input_genes, n_batch))
+        elif self.gene_dispersion == "gene-label":
+            self.px_r = torch.nn.Parameter(torch.randn(n_input_genes, n_labels))
+        else:  # gene-cell
+            pass
+
+        if self.protein_dispersion == "protein":
+            self.py_r = torch.nn.Parameter(2 * torch.rand(self.n_input_proteins))
+        elif self.protein_dispersion == "protein-batch":
+            self.py_r = torch.nn.Parameter(
+                2 * torch.rand(self.n_input_proteins, n_batch)
+            )
+        elif self.protein_dispersion == "protein-label":
+            self.py_r = torch.nn.Parameter(
+                2 * torch.rand(self.n_input_proteins, n_labels)
+            )
+        else:  # protein-cell
+            pass
+
+        use_batch_norm_encoder = use_batch_norm == "encoder" or use_batch_norm == "both"
+        use_batch_norm_decoder = use_batch_norm == "decoder" or use_batch_norm == "both"
+        use_layer_norm_encoder = use_layer_norm == "encoder" or use_layer_norm == "both"
+        use_layer_norm_decoder = use_layer_norm == "decoder" or use_layer_norm == "both"
+
+        # z encoder goes from the n_input-dimensional data to an n_latent-d
+        # latent space representation
+        n_input = n_input_genes + self.n_input_proteins
+        n_input_encoder = n_input + n_continuous_cov * encode_covariates
+        cat_list = [n_batch] + list([] if n_cats_per_cov is None else n_cats_per_cov)
+        encoder_cat_list = cat_list if encode_covariates else None
+        self.z_encoder = EncoderTOTALVI(
+            n_input_encoder,
+            n_background_latent,
+            n_layers=n_layers_encoder,
+            n_cat_list=encoder_cat_list,
+            n_hidden=n_hidden,
+            dropout_rate=dropout_rate_encoder,
+            distribution=latent_distribution,
+            use_batch_norm=use_batch_norm_encoder,
+            use_layer_norm=use_layer_norm_encoder,
+        )
+
+        self.s_encoder = EncoderTOTALVI(
+            n_input_encoder,
+            n_salient_latent,
+            n_layers=n_layers_encoder,
+            n_cat_list=encoder_cat_list,
+            n_hidden=n_hidden,
+            dropout_rate=dropout_rate_encoder,
+            distribution=latent_distribution,
+            use_batch_norm=use_batch_norm_encoder,
+            use_layer_norm=use_layer_norm_encoder,
+        )
+        n_total_latent = n_background_latent + n_salient_latent
+        self.decoder = DecoderTOTALVI(
+            n_total_latent + n_continuous_cov,
+            n_input_genes,
+            self.n_input_proteins,
+            n_layers=n_layers_decoder,
+            n_cat_list=cat_list,
+            n_hidden=n_hidden,
+            dropout_rate=dropout_rate_decoder,
+            use_batch_norm=use_batch_norm_decoder,
+            use_layer_norm=use_layer_norm_decoder,
+            scale_activation="softplus" if use_size_factor_key else "softmax",
+        )
+
+    @auto_move_data
+    def _compute_local_library_params(
+        self, batch_index: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        n_batch = self.library_log_means.shape[1]
+        local_library_log_means = F.linear(
+            one_hot(batch_index, n_batch), self.library_log_means
+        )
+        local_library_log_vars = F.linear(
+            one_hot(batch_index, n_batch), self.library_log_vars
+        )
+        return local_library_log_means, local_library_log_vars
+
+    @staticmethod
+    def _get_min_batch_size(concat_tensors: Dict[str, Dict[str, torch.Tensor]]) -> int:
+        return min(
+            concat_tensors["background"][REGISTRY_KEYS.X_KEY].shape[0],
+            concat_tensors["target"][REGISTRY_KEYS.X_KEY].shape[0],
+        )
+
+    @staticmethod
+    def _reduce_tensors_to_min_batch_size(
+        tensors: Dict[str, torch.Tensor], min_batch_size: int
+    ) -> None:
+        for name, tensor in tensors.items():
+            tensors[name] = tensor[:min_batch_size, :]
+
+    @staticmethod
+    def _get_inference_input_from_concat_tensors(
+        concat_tensors: Dict[str, Dict[str, torch.Tensor]], index: str
+    ) -> Dict[str, torch.Tensor]:
+        tensors = concat_tensors[index]
+        x = tensors[REGISTRY_KEYS.X_KEY]
+        y = tensors[REGISTRY_KEYS.PROTEIN_EXP_KEY]
+        batch_index = tensors[REGISTRY_KEYS.BATCH_KEY]
+        input_dict = dict(x=x, y=y, batch_index=batch_index)
+        return input_dict
+
+    def _get_inference_input(
+        self, concat_tensors: Dict[str, Dict[str, torch.Tensor]]
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        background = self._get_inference_input_from_concat_tensors(
+            concat_tensors, "background"
+        )
+        target = self._get_inference_input_from_concat_tensors(concat_tensors, "target")
+        # Ensure batch sizes are the same.
+        min_batch_size = self._get_min_batch_size(concat_tensors)
+        self._reduce_tensors_to_min_batch_size(background, min_batch_size)
+        self._reduce_tensors_to_min_batch_size(target, min_batch_size)
+        return dict(background=background, target=target)
+
+    @staticmethod
+    def _get_generative_input_from_concat_tensors(
+        concat_tensors: Dict[str, Dict[str, torch.Tensor]], index: str
+    ) -> Dict[str, torch.Tensor]:
+        tensors = concat_tensors[index]
+        batch_index = tensors[REGISTRY_KEYS.BATCH_KEY]
+        input_dict = dict(batch_index=batch_index)
+        return input_dict
+
+    @staticmethod
+    def _get_generative_input_from_inference_outputs(
+        inference_outputs: Dict[str, Dict[str, torch.Tensor]], data_source: str
+    ) -> Dict[str, torch.Tensor]:
+        z = inference_outputs[data_source]["z"]
+        s = inference_outputs[data_source]["s"]
+        library_gene = inference_outputs[data_source]["library_gene"]
+        return dict(z=z, s=s, library_gene=library_gene)
+
+    def _get_generative_input(
+        self,
+        concat_tensors: Dict[str, Dict[str, torch.Tensor]],
+        inference_outputs: Dict[str, Dict[str, torch.Tensor]],
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        background_tensor_input = self._get_generative_input_from_concat_tensors(
+            concat_tensors, "background"
+        )
+        target_tensor_input = self._get_generative_input_from_concat_tensors(
+            concat_tensors, "target"
+        )
+        # Ensure batch sizes are the same.
+        min_batch_size = self._get_min_batch_size(concat_tensors)
+        self._reduce_tensors_to_min_batch_size(background_tensor_input, min_batch_size)
+        self._reduce_tensors_to_min_batch_size(target_tensor_input, min_batch_size)
+
+        background_inference_outputs = (
+            self._get_generative_input_from_inference_outputs(
+                inference_outputs, "background"
+            )
+        )
+        target_inference_outputs = self._get_generative_input_from_inference_outputs(
+            inference_outputs, "target"
+        )
+        background = {**background_tensor_input, **background_inference_outputs}
+        target = {**target_tensor_input, **target_inference_outputs}
+        return dict(background=background, target=target)
+
+    @staticmethod
+    def _reshape_tensor_for_samples(tensor: torch.Tensor, n_samples: int):
+        return tensor.unsqueeze(0).expand((n_samples, tensor.size(0), tensor.size(1)))
+
+    @auto_move_data
+    def _generic_inference(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        batch_index: torch.Tensor,
+        n_samples: int = 1,
+    ) -> Dict[str, torch.Tensor]:
+        x_ = x
+        y_ = y
+        if self.use_observed_lib_size:
+            library_gene = x.sum(1).unsqueeze(1)
+        x_ = torch.log(1 + x_)
+        y_ = torch.log(1 + y_)
+        encoder_input = torch.cat((x_, y_), dim=-1)
+
+        (
+            qz_m,
+            qz_v,
+            ql_m,
+            ql_v,
+            background_latent,
+            untran_background_latent,
+        ) = self.z_encoder(encoder_input, batch_index)
+        z = background_latent["z"]
+        untran_z = untran_background_latent["z"]
+        untran_l = untran_background_latent["l"]  # Library encoder used and updated.
+        (qs_m, qs_v, _, _, salient_latent, untran_salient_latent) = self.s_encoder(
+            encoder_input, batch_index
+        )
+        s = salient_latent["z"]
+        untran_s = untran_salient_latent["z"]
+        # Library encoder not used and not updated.
+
+        if not self.use_observed_lib_size:
+            library_gene = background_latent["l"]
+
+        if n_samples > 1:
+            qz_m = self._reshape_tensor_for_samples(qz_m, n_samples)
+            qz_v = self._reshape_tensor_for_samples(qz_v, n_samples)
+            untran_z = Normal(qz_m, qz_v.sqrt()).sample()
+            z = self.z_encoder.z_transformation(untran_z)
+
+            qs_m = self._reshape_tensor_for_samples(qs_m, n_samples)
+            qs_v = self._reshape_tensor_for_samples(qs_v, n_samples)
+            untran_s = Normal(qs_m, qs_v.sqrt()).sample()
+            s = self.s_encoder.z_transformation(untran_s)
+
+            ql_m = self._reshape_tensor_for_samples(ql_m, n_samples)
+            ql_v = self._reshape_tensor_for_samples(ql_v, n_samples)
+            untran_l = Normal(ql_m, ql_v.sqrt()).sample()
+
+            if self.use_observed_lib_size:
+                library_gene = self._reshape_tensor_for_samples(library_gene, n_samples)
+            else:
+                library_gene = self.z_encoder.l_transformation(untran_l)
+
+        if self.n_batch > 0:
+            py_back_alpha_prior = F.linear(
+                one_hot(batch_index, self.n_batch), self.background_pro_alpha
+            )
+            py_back_beta_prior = F.linear(
+                one_hot(batch_index, self.n_batch),
+                torch.exp(self.background_pro_log_beta),
+            )
+        else:
+            py_back_alpha_prior = self.background_pro_alpha
+            py_back_beta_prior = torch.exp(self.background_pro_log_beta)
+
+        back_mean_prior = Normal(py_back_alpha_prior, py_back_beta_prior)
+
+        outputs = dict(
+            untran_z=untran_z,
+            z=z,
+            qz_m=qz_m,
+            qz_v=qz_v,
+            untran_s=untran_s,
+            s=s,
+            qs_m=qs_m,
+            qs_v=qs_v,
+            library_gene=library_gene,
+            ql_m=ql_m,
+            ql_v=ql_v,
+            untran_l=untran_l,
+            back_mean_prior=back_mean_prior
+        )
+        return outputs
+
+    @auto_move_data
+    def inference(
+        self,
+        background: Dict[str, torch.Tensor],
+        target: Dict[str, torch.Tensor],
+        n_samples: int = 1,
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        background_outputs = self._generic_inference(**background, n_samples=n_samples)
+        target_outputs = self._generic_inference(**target, n_samples=n_samples)
+        background_outputs["s"] = torch.zeros_like(background_outputs["s"])
+        return dict(background=background_outputs, target=target_outputs)
+
+    @auto_move_data
+    def _generic_generative(
+        self,
+        z: torch.Tensor,
+        s: torch.Tensor,
+        library_gene: torch.Tensor,
+        batch_index: torch.Tensor,
+    ) -> Dict[str, torch.Tensor]:
+        latent = torch.cat([z, s], dim=-1)
+        px_, py_, log_pro_back_mean = self.decoder(
+            latent,
+            library_gene,
+            batch_index,
+        )
+        px_r = torch.exp(self.px_r)
+        py_r = torch.exp(self.py_r)
+        px_["r"] = px_r
+        py_["r"] = py_r
+        return dict(px_=px_, py_=py_, log_pro_back_mean=log_pro_back_mean)
+
+    @auto_move_data
+    def generative(
+        self,
+        background: Dict[str, torch.Tensor],
+        target: Dict[str, torch.Tensor],
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        latent_z_shape = background["z"].shape
+        batch_size_dim = 0 if len(latent_z_shape) == 2 else 1
+        background_batch_size = background["z"].shape[batch_size_dim]
+        target_batch_size = target["z"].shape[batch_size_dim]
+        generative_input = {}
+        for key in ["z", "s", "library_gene"]:
+            generative_input[key] = torch.cat(
+                [background[key], target[key]], dim=batch_size_dim
+            )
+        generative_input["batch_index"] = torch.cat(
+            [background["batch_index"], target["batch_index"]], dim=0
+        )
+        outputs = self._generic_generative(**generative_input)
+
+        # Split outputs into corresponding background and target set.
+        background_outputs = {"px_": {}, "py_": {}}
+        target_outputs = {"px_": {}, "py_": {}}
+        for modality in ["px_", "py_"]:
+            for key in outputs[modality].keys():
+                if key == "r":
+                    background_tensor = outputs[modality][key]
+                    target_tensor = outputs[modality][key]
+                else:
+                    if outputs[modality][key] is not None:
+                        background_tensor, target_tensor = torch.split(
+                            outputs[modality][key],
+                            [background_batch_size, target_batch_size],
+                            dim=batch_size_dim,
+                        )
+                    else:
+                        background_tensor, target_tensor = None, None
+                background_outputs[modality][key] = background_tensor
+                target_outputs[modality][key] = target_tensor
+
+        if outputs["log_pro_back_mean"] is not None:
+            background_tensor, target_tensor = torch.split(
+                outputs["log_pro_back_mean"],
+                [background_batch_size, target_batch_size],
+                dim=batch_size_dim,
+            )
+        else:
+            background_tensor, target_tensor = None, None
+        background_outputs["log_pro_back_mean"] = background_tensor
+        target_outputs["log_pro_back_mean"] = target_tensor
+
+        return dict(background=background_outputs, target=target_outputs)
+
+    @staticmethod
+    def get_reconstruction_loss(
+        x: torch.Tensor,
+        y: torch.Tensor,
+        px_dict: Dict[str, torch.Tensor],
+        py_dict: Dict[str, torch.Tensor],
+        pro_batch_mask_minibatch: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute reconstruction loss."""
+        px_ = px_dict
+        py_ = py_dict
+
+        reconst_loss_gene = (
+            -NegativeBinomial(mu=px_["rate"], theta=px_["r"]).log_prob(x).sum(dim=-1)
+        )
+
+        py_conditional = NegativeBinomialMixture(
+            mu1=py_["rate_back"],
+            mu2=py_["rate_fore"],
+            theta1=py_["r"],
+            mixture_logits=py_["mixing"],
+        )
+        reconst_loss_protein_full = -py_conditional.log_prob(y)
+        if pro_batch_mask_minibatch is not None:
+            temp_pro_loss_full = torch.zeros_like(reconst_loss_protein_full)
+            temp_pro_loss_full.masked_scatter_(
+                pro_batch_mask_minibatch.bool(), reconst_loss_protein_full
+            )
+
+            reconst_loss_protein = temp_pro_loss_full.sum(dim=-1)
+        else:
+            reconst_loss_protein = reconst_loss_protein_full.sum(dim=-1)
+
+        return reconst_loss_gene, reconst_loss_protein
+
+    @staticmethod
+    def latent_kl_divergence(
+        variational_mean: torch.Tensor,
+        variational_var: torch.Tensor,
+        prior_mean: torch.Tensor,
+        prior_var: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Compute KL divergence between a variational posterior and prior Gaussian.
+        Args:
+        ----
+            variational_mean: Mean of the variational posterior Gaussian.
+            variational_var: Variance of the variational posterior Gaussian.
+            prior_mean: Mean of the prior Gaussian.
+            prior_var: Variance of the prior Gaussian.
+
+        Returns
+        -------
+            KL divergence for each data point. If number of latent samples == 1,
+            the tensor has shape `(batch_size, )`. If number of latent
+            samples > 1, the tensor has shape `(n_samples, batch_size)`.
+        """
+        return kl(
+            Normal(variational_mean, variational_var.sqrt()),
+            Normal(prior_mean, prior_var.sqrt()),
+        ).sum(dim=-1)
+
+    def library_gene_kl_divergence(
+        self,
+        batch_index: torch.Tensor,
+        variational_library_mean: torch.Tensor,
+        variational_library_var: torch.Tensor,
+        library: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Compute KL divergence between library size variational posterior and prior.
+
+        Both the variational posterior and prior are Log-Normal.
+        Args:
+        ----
+            batch_index: Batch indices for batch-specific library size mean and
+                variance.
+            variational_library_mean: Mean of variational Log-Normal.
+            variational_library_var: Variance of variational Log-Normal.
+            library: Sampled library size.
+
+        Returns
+        -------
+            KL divergence for each data point. If number of latent samples == 1,
+            the tensor has shape `(batch_size, )`. If number of latent
+            samples > 1, the tensor has shape `(n_samples, batch_size)`.
+        """
+        if not self.use_observed_lib_size:
+            (
+                local_library_log_means,
+                local_library_log_vars,
+            ) = self._compute_local_library_params(batch_index)
+
+            kl_library = kl(
+                Normal(variational_library_mean, variational_library_var.sqrt()),
+                Normal(local_library_log_means, local_library_log_vars.sqrt()),
+            )
+        else:
+            kl_library = torch.zeros_like(library)
+        return kl_library.sum(dim=-1)
+
+    def _generic_loss(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        inference_outputs: Dict[str, torch.Tensor],
+        generative_outputs: Dict[str, torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
+        x = tensors[REGISTRY_KEYS.X_KEY]
+        y = tensors[REGISTRY_KEYS.PROTEIN_EXP_KEY]
+        batch_index = tensors[REGISTRY_KEYS.BATCH_KEY]
+
+        qz_m = inference_outputs["qz_m"]
+        qz_v = inference_outputs["qz_v"]
+        qs_m = inference_outputs["qs_m"]
+        qs_v = inference_outputs["qs_v"]
+        ql_m = inference_outputs["ql_m"]
+        ql_v = inference_outputs["ql_v"]
+        library_gene = inference_outputs["library_gene"]
+        px_ = generative_outputs["px_"]
+        py_ = generative_outputs["py_"]
+
+        prior_z_m = torch.zeros_like(qz_m)
+        prior_z_v = torch.ones_like(qz_v)
+        prior_s_m = torch.zeros_like(qs_m)
+        prior_s_v = torch.ones_like(qs_v)
+
+        if self.protein_batch_mask is not None:
+            pro_batch_mask_minibatch = torch.zeros_like(y)
+            for b in torch.unique(batch_index):
+                b_indices = (batch_index == b).reshape(-1)
+                pro_batch_mask_minibatch[b_indices] = torch.tensor(
+                    self.protein_batch_mask[b.item()].astype(np.float32),
+                    device=y.device,
+                )
+        else:
+            pro_batch_mask_minibatch = None
+        reconst_loss_gene, reconst_loss_protein = self.get_reconstruction_loss(
+            x, y, px_, py_, pro_batch_mask_minibatch
+        )
+
+        kl_z = self.latent_kl_divergence(qz_m, qz_v, prior_z_m, prior_z_v)
+        kl_s = self.latent_kl_divergence(qs_m, qs_v, prior_s_m, prior_s_v)
+        kl_library_gene = self.library_gene_kl_divergence(
+            batch_index, ql_m, ql_v, library_gene
+        )
+
+        kl_div_back_pro_full = kl(
+            Normal(py_["back_alpha"], py_["back_beta"]), inference_outputs["back_mean_prior"]
+        )
+        if pro_batch_mask_minibatch is not None:
+            kl_div_back_pro = (pro_batch_mask_minibatch * kl_div_back_pro_full).sum(
+                dim=-1
+            )
+        else:
+            kl_div_back_pro = kl_div_back_pro_full.sum(dim=-1)
+
+        return dict(
+            reconst_loss_gene=reconst_loss_gene,
+            reconst_loss_protein=reconst_loss_protein,
+            kl_z=kl_z,
+            kl_s=kl_s,
+            kl_library_gene=kl_library_gene,
+            kl_div_back_pro=kl_div_back_pro,
+        )
+
+    def loss(
+        self,
+        concat_tensors: Dict[str, Dict[str, torch.Tensor]],
+        inference_outputs: Dict[str, Dict[str, torch.Tensor]],
+        generative_outputs: Dict[str, Dict[str, torch.Tensor]],
+    ) -> LossRecorder:
+        """
+        Compute loss terms for contrastive-VI.
+        Args:
+        ----
+            concat_tensors: Tuple of data mini-batch. The first element contains
+                background data mini-batch. The second element contains target data
+                mini-batch.
+            inference_outputs: Dictionary of inference step outputs. The keys
+                are "background" and "target" for the corresponding outputs.
+            generative_outputs: Dictionary of generative step outputs. The keys
+                are "background" and "target" for the corresponding outputs.
+
+        Returns
+        -------
+            An scvi.module.base.LossRecorder instance that records the losses.
+        """
+        background_tensors = concat_tensors["background"]
+        target_tensors = concat_tensors["target"]
+        # Ensure batch sizes are the same.
+        min_batch_size = self._get_min_batch_size(concat_tensors)
+        self._reduce_tensors_to_min_batch_size(background_tensors, min_batch_size)
+        self._reduce_tensors_to_min_batch_size(target_tensors, min_batch_size)
+
+        background_losses = self._generic_loss(
+            background_tensors,
+            inference_outputs["background"],
+            generative_outputs["background"],
+        )
+        target_losses = self._generic_loss(
+            target_tensors,
+            inference_outputs["target"],
+            generative_outputs["target"],
+        )
+
+        reconst_loss_gene = (
+            background_losses["reconst_loss_gene"] + target_losses["reconst_loss_gene"]
+        )
+        reconst_loss_protein = (
+            background_losses["reconst_loss_protein"]
+            + target_losses["reconst_loss_protein"]
+        )
+        reconst_losses = dict(
+            reconst_loss_gene=reconst_loss_gene,
+            reconst_loss_protein=reconst_loss_protein,
+        )
+
+        kl_z = background_losses["kl_z"] + target_losses["kl_z"]
+        kl_s = target_losses["kl_s"]
+        kl_library_gene = (
+            background_losses["kl_library_gene"] + target_losses["kl_library_gene"]
+        )
+        kl_div_back_pro = (
+            background_losses["kl_div_back_pro"] + target_losses["kl_div_back_pro"]
+        )
+
+        loss = torch.mean(
+            reconst_loss_gene
+            + reconst_loss_protein
+            + kl_z
+            + kl_s
+            + kl_library_gene
+            + kl_div_back_pro
+        )
+
+        kl_local = dict(
+            kl_z=kl_z,
+            kl_s=kl_s,
+            kl_library_gene=kl_library_gene,
+            kl_div_back_pro=kl_div_back_pro,
+        )
+        kl_global = torch.tensor(0.0)
+        return LossRecorder(loss, reconst_losses, kl_local, kl_global)
+
+    @torch.no_grad()
+    def sample_mean(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        data_source: str,
+        n_samples: int = 1,
+    ) -> torch.Tensor:
+        """Sample posterior mean."""
+        raise NotImplementedError
+
+    @torch.no_grad()
+    def sample(self):
+        raise NotImplementedError
+
+    @torch.no_grad()
+    @auto_move_data
+    def marginal_ll(self):
+        raise NotImplementedError


### PR DESCRIPTION
Currently the main contrastiveVI repository is missing an
implementation of the totalContrastiveVI model. This PR adds
the model/module files for totalContrastiveVI. The code is
mostly the same as the implementation in the reproducibility repository,
with some changes made to accommodate differences between scvi-tools
library versions.

I did my best to limit the changes to only what was necessary to get the code
working on scvi-tools 0.16, but I left comments to clarify some potentially confusing points.