### PR TITLE
Bugfix: add back target vs background de test

### DIFF
--- a/contrastive_vi/model/contrastive_vi.py
+++ b/contrastive_vi/model/contrastive_vi.py
@@ -690,7 +690,7 @@ class ContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
             )
 
         result = _de_core(
-            adata,
+            self.get_anndata_manager(adata, required=True),
             model_fn,
             groupby=groupby,
             group1=group1,

--- a/contrastive_vi/model/contrastive_vi.py
+++ b/contrastive_vi/model/contrastive_vi.py
@@ -604,6 +604,7 @@ class ContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
         fdr_target: float = 0.05,
         silent: bool = False,
         target_idx: Optional[Sequence[int]] = None,
+        n_samples: int = 1,
         **kwargs,
     ) -> pd.DataFrame:
         r"""
@@ -674,7 +675,7 @@ class ContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
             model_fn = partial(
                 self.get_specific_normalized_expression,
                 return_numpy=True,
-                n_samples=100,
+                n_samples=n_samples,
                 batch_size=batch_size,
                 expression_type=None,
                 indices_to_return_salient=target_idx,
@@ -683,7 +684,7 @@ class ContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
             model_fn = partial(
                 self.get_specific_normalized_expression,
                 return_numpy=True,
-                n_samples=100,
+                n_samples=n_samples,
                 batch_size=batch_size,
                 expression_type="salient",
                 indices_to_return_salient=None,

--- a/contrastive_vi/model/total_contrastive_vi.py
+++ b/contrastive_vi/model/total_contrastive_vi.py
@@ -729,7 +729,7 @@ class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
             )
 
         result = _de_core(
-            adata,
+            self.get_anndata_manager(adata, required=True),
             model_fn,
             groupby,
             group1,

--- a/contrastive_vi/model/total_contrastive_vi.py
+++ b/contrastive_vi/model/total_contrastive_vi.py
@@ -714,7 +714,7 @@ class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
                 batch_size=batch_size,
                 expression_type=None,
                 indices_to_return_salient=target_idx,
-                n_samples=1,
+                n_samples=100,
             )
         else:
             model_fn = partial(
@@ -725,7 +725,7 @@ class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
                 protein_prior_count=protein_prior_count,
                 batch_size=batch_size,
                 expression_type="salient",
-                n_samples=1,
+                n_samples=100,
             )
 
         result = _de_core(

--- a/contrastive_vi/model/total_contrastive_vi.py
+++ b/contrastive_vi/model/total_contrastive_vi.py
@@ -714,7 +714,7 @@ class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
                 batch_size=batch_size,
                 expression_type=None,
                 indices_to_return_salient=target_idx,
-                n_samples=100,
+                n_samples=1,
             )
         else:
             model_fn = partial(
@@ -725,7 +725,7 @@ class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
                 protein_prior_count=protein_prior_count,
                 batch_size=batch_size,
                 expression_type="salient",
-                n_samples=100,
+                n_samples=1,
             )
 
         result = _de_core(


### PR DESCRIPTION
When we compare target versus background samples using a differential expression test, we need to explicitly zero out salient latent variables for the background samples. This PR adds back in the `target_idx` argument to our differential expression functions so that we can specify which samples are target versus background.