### PR TITLE
Add functions for obtaining latent library size values

### DIFF
--- a/contrastive_vi/model/total_contrastive_vi.py
+++ b/contrastive_vi/model/total_contrastive_vi.py
@@ -755,8 +755,8 @@ class TotalContrastiveVIModel(ContrastiveTrainingMixin, BaseModelClass):
         batch_size: Optional[int] = None,
     ) -> np.ndarray:
         r"""
-        Returns the latent library size for each cell.
-        This is denoted as :math:`\ell_n` in the scVI paper.
+        Returns the latent RNA library size for each cell.
+        This is denoted as :math:`\ell_n` in the totalVI paper.
         Parameters
         ----------
         adata


### PR DESCRIPTION
In order to obtain denoiesd RNA/protein count values, we need methods for obtaining the latent library size variables inferred by contrastiveVI/totalContrastiveVI. This PR adds those functions to our model classes. The code from these functions is largely reused from scVI/totalVI.